### PR TITLE
Fix items with tags

### DIFF
--- a/locale/en/space-factorissimo.cfg
+++ b/locale/en/space-factorissimo.cfg
@@ -2,21 +2,32 @@
 space-factory-1=Space Factory building 1
 space-factory-2=Space Factory building 2
 space-factory-3=Space Factory building 3
+grav-factory-1=Space Grav Factory building 1
+grav-factory-2=Space Grav Factory building 2
+grav-factory-3=Space Grav Factory building 3
 
 [entity-description]
 space-factory-1=Interior space: 30x30\nConnections: 16\n\n__CONTROL__factory-rotate__ to toggle port markers (requires alt-view)
 space-factory-2=Interior space: 46x46\nConnections: 24\n\n__CONTROL__factory-rotate__ to toggle port markers (requires alt-view)
 space-factory-3=Interior space: 60x60\nConnections: 32\n\n__CONTROL__factory-rotate__ to toggle port markers (requires alt-view)
+grav-factory-1=Interior space: 30x30\nConnections: 16\n\n__CONTROL__factory-rotate__ to toggle port markers (requires alt-view)
+grav-factory-2=Interior space: 46x46\nConnections: 24\n\n__CONTROL__factory-rotate__ to toggle port markers (requires alt-view)
+grav-factory-3=Interior space: 60x60\nConnections: 32\n\n__CONTROL__factory-rotate__ to toggle port markers (requires alt-view)
 
 [technology-name]
 space-factory-architecture-t1=Space Architecture 1
 space-factory-architecture-t2=Space Architecture 2
 space-factory-architecture-t3=Space Architecture 3
+space-gravFactory-architecture=Space Grav Factory Architecture
 
 [tile-name]
 space-factory-floor=Space Factory floor
 out-of-space-factory=Space Factory floor
 space-factory-entrance=Space Factory entrance
+
+grav-factory-floor=Space Grav Factory floor
+out-of-grav-factory=Space Grav Factory floor
+grav-factory-entrance=Space Grav Factory entrance
 
 space-factory-pattern-1=Space Factory 1 pattern
 space-factory-wall-1=Space Factory 1 wall
@@ -26,6 +37,15 @@ space-factory-wall-2=Space Factory 2 wall
 
 space-factory-pattern-3=Space Factory 3 pattern
 space-factory-wall-3=Space Factory 3 wall
+
+grav-factory-pattern-1=Space Grav Factory 1 pattern
+grav-factory-wall-1=Space Grav Factory 1 wall
+
+grav-factory-pattern-2=Space Grav Factory 2 pattern
+grav-factory-wall-2=Space Grav Factory 2 wall
+
+grav-factory-pattern-3=Space Grav Factory 3 pattern
+grav-factory-wall-3=Space Grav Factory 3 wall
 
 [controls]
 factory-rotate=Change connection direction

--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -85,7 +85,7 @@ local function factory_prototype(name,tier, map_color, factory_default)
             map_color = map_color,
             is_military_target = true
         },
---[[        {
+        {
             type = "item-with-tags",
             name = name,
             --localised_name = { "entity-name." .. name },
@@ -95,10 +95,10 @@ local function factory_prototype(name,tier, map_color, factory_default)
             order = "a-c",
             place_result = name,
             stack_size = 1
-        }, ]]
+        },
         {
             type = "item",
-            name = name,
+            name = name .. "-raw",
             --localised_name = { "entity-name." .. name },
             icon = local_prefix .. "/graphics/icon/" .. name .. ".png",
             icon_size = 64,

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -15,7 +15,7 @@ data:extend{
 		enabled = false,
 		energy_required = 30,
 		ingredients = {{ "se-space-platform-scaffold", 500 }, { "se-heat-shielding", 500 }, { "substation", 10 }},
-		result = sff_1
+		result = sff_1 .. "-raw",
 	},
 	{
 		type = "recipe",
@@ -23,7 +23,7 @@ data:extend{
 		enabled = false,
 		energy_required = 45,
 		ingredients = {{ "se-space-platform-scaffold", 1000 }, { "se-heat-shielding", 1000 }, { "substation", 50 }},
- 		result = sff_2
+		result = sff_2 .. "-raw",
 	},
 	{
 		type = "recipe",
@@ -31,7 +31,7 @@ data:extend{
 		enabled = false,
 		energy_required = 60,
 		ingredients = {{ "se-space-platform-plating", 5000 }, { "se-heat-shielding", 2000 }, { "substation", 100 }},
-		result = sff_3
+		result = sff_3 .. "-raw",
 	},
 
 	-- Grav Factories
@@ -41,7 +41,7 @@ data:extend{
 		enabled = false,
 		energy_required = 30,
 		ingredients = {{"se-space-platform-plating", 500}, { "se-heat-shielding", 500 }, { "substation", 10 }},
-		result = sgf_1
+		result = sgf_1 .. "-raw",
 	},
 	{
 		type = "recipe",
@@ -49,7 +49,7 @@ data:extend{
 		enabled = false,
 		energy_required = 45,
 		ingredients = {{"se-space-platform-plating", 1000}, { "se-heat-shielding", 1000 }, { "substation", 50 }},
- 		result = sgf_2
+		result = sgf_2 .. "-raw",
 	},
 	{
 		type = "recipe",
@@ -57,7 +57,7 @@ data:extend{
 		enabled = false,
 		energy_required = 60,
 		ingredients = {{"se-space-platform-plating", 5000}, { "se-heat-shielding", 2000 }, { "substation", 100 }},
-		result = sgf_3
+		result = sgf_3 .. "-raw",
 	},
 	-- Utilities
 	{


### PR DESCRIPTION
The factory prototypes were setup in a wrong way, which meant you couldn't pick them up or place ghosts for them to built by robots. This aligns the prototype creating with the Factorissimo mod's way.

Also added descriptions to items that didn't have them.